### PR TITLE
update license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "SEE LICENSE IN LICENSE.md",
   "devDependencies": {},
   "dependencies": {
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
I noticed that the package.json listed "ISC" as the license (the `npm init` default), but there is an included MIT license. I've updated the package.json to reference that LICENSE file per suggestion here: https://docs.npmjs.com/files/package.json\#license