### PR TITLE
JUMPI Sheep

### DIFF
--- a/GasProfile.json
+++ b/GasProfile.json
@@ -21,12 +21,12 @@
   "emptyApprovalReducingToBurn": 34596,
   "reduceApprovalEmptyingToBurn": 34532,
   "emptyApprovalEmptyingToBurn": 24676,
-  "reduceToNewWithRefund": 35415,
+  "reduceToNewWithRefund": 35414,
   "reduceToExistingWithRefund": 27551,
   "emptyToExistingWithRefund": 24661,
   "emptyToNewWithRefund": 35088,
-  "reduceApprovalReducingToNewWithRefund": 38825,
-  "reduceApprovalReducingToExistingWithRefund": 31319,
+  "reduceApprovalReducingToNewWithRefund": 38824,
+  "reduceApprovalReducingToExistingWithRefund": 31318,
   "reduceApprovalEmptyingToNewWithRefund": 38504,
   "reduceApprovalEmptyingToExistingWithRefund": 28459,
   "emptyApprovalReducingToNewWithRefund": 38472,
@@ -39,10 +39,10 @@
   "burnMicroDollarWithRefund": 28982,
   "reduceToBurnWithChangeWithRefund": 29014,
   "emptyToBurnWithChangeWithRefund": 29014,
-  "reduceApprovalReducingToBurnWithRefund": 32749,
+  "reduceApprovalReducingToBurnWithRefund": 32748,
   "emptyApprovalReducingToBurnWithRefund": 29921,
   "reduceApprovalEmptyingToBurnWithRefund": 29889,
   "emptyApprovalEmptyingToBurnWithRefund": 24676,
   "sponsorGas": 208304,
-  "sponsorGas2": 203365
+  "sponsorGas2": 200949
 }

--- a/contracts/GasRefundToken.sol
+++ b/contracts/GasRefundToken.sol
@@ -19,37 +19,33 @@ contract GasRefundToken is ProxyStorage {
         /**
         Deploy (9 bytes)
           PC Assembly       Opcodes                                       Stack
-          00 PUSH1(31)      60 1f                                         1f
-          02 DUP1           80                                            1f 1f
-          03 PUSH1(9)       60 09                                         1f 1f 09
-          05 RETURNDATASIZE 3d                                            1f 1f 09 00
-          06 CODECOPY       39                                            1f
-          07 RETURNDATASIZE 3d                                            1f 00
+          00 PUSH1(27)      60 1b                                         1b
+          02 DUP1           80                                            1b 1b
+          03 PUSH1(9)       60 09                                         1b 1b 09
+          05 RETURNDATASIZE 3d                                            1b 1b 09 00
+          06 CODECOPY       39                                            1b
+          07 RETURNDATASIZE 3d                                            1b 00
           08 RETURN         f3
-        Sheep (31 bytes = 3 + 20 + 8)
+        Sheep (27 bytes = 3 + 20 + 4)
           PC Assembly       Opcodes                                       Stack
-          00 RETURNDATASIZE 3d                                            0
-          01 CALLER         33                                            0 caller
-          02 PUSH20(me)     73 memememememememememememememememememememe   0 caller me
-          17 EQ             14                                            0 valid
-          18 PUSH1(1d)      60 1d                                         0 valid 1d
-          1a JUMPI          57                                            0
-          1b DUP1           80                                            0 0
-          1c REVERT         fd
-          1d JUMPDEST       5b                                            0
-          1e SELFDESTRUCT   ff
+          00 RETURNDATASIZE 3d                                            00
+          01 CALLER         33                                            00 caller
+          02 PUSH20(me)     73 memememememememememememememememememememe   00 caller me
+          17 XOR            18                                            00 invalid
+          18 PC             58                                            00 invalid 18
+          19 JUMPI          57                                            00
+          1a SELFDESTRUCT   ff
         */
         assembly {
-            mstore(0, or(0x601f8060093d393df33d33730000000000000000000000000000000000000000, address))
-            mstore(32,   0x14601d5780fd5bff000000000000000000000000000000000000000000000000)
-            let sheep := create(0, 0, 0x28)
+            mstore(0, or(0x601b8060093d393df33d33730000000000000000000000000000000000000000, address))
+            mstore(32,   0x185857ff00000000000000000000000000000000000000000000000000000000)
             let offset := sload(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
             let location := sub(0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe, offset)
-            sstore(location, sheep)
-            sheep := create(0, 0, 0x28)
-            sstore(sub(location, 1), sheep)
-            sheep := create(0, 0, 0x28)
-            sstore(sub(location, 2), sheep)
+            sstore(location, create(0, 0, 0x24))
+            location := sub(location, 1)
+            sstore(location, create(0, 0, 0x24))
+            location := sub(location, 1)
+            sstore(location, create(0, 0, 0x24))
             sstore(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, add(offset, 3))
         }
     }

--- a/test/GasRefundToken.test.js
+++ b/test/GasRefundToken.test.js
@@ -77,10 +77,19 @@ contract('GasRefundToken', function (accounts) {
             assert(firstContract != secondContract, 'first and second contracts are the same')
             assert(secondContract != thirdContract, 'second and third contracts are the same')
             assert(firstContract != thirdContract, 'first and third contracts are the same')
+            for (let contract of [firstContract, secondContract, thirdContract]) {
+                const sheepCode = await web3.eth.getCode(contract)
+                assert.equal(sheepCode.length, 56, 'sheep wrong size');
+                const Sheep = await TrueUSD.at(contract)
+                await assertRevert(Sheep.totalSupply(), {from: anotherAccount})
+            }
             const reduceToNewWithRefund = await this.token.transfer(owner, BN(20*10**18), { from: oneHundred })
             const poolSizeUsed = await web3.eth.getStorageAt(this.token.address, '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
             assert.equal(poolSizeUsed, '0x02')
             assert.isBelow(reduceToNewWithRefund.receipt.gasUsed, reduceToNewNoRefund.receipt.gasUsed)
+            // verify that calling the sheep impoperly causes revert
+            const selfdestructCode = await web3.eth.getCode(thirdContract)
+            assert.equal(selfdestructCode,'0x', 'contract did not self destruct');
         })
     })
 })

--- a/test/GasRefundToken.test.js
+++ b/test/GasRefundToken.test.js
@@ -81,13 +81,13 @@ contract('GasRefundToken', function (accounts) {
                 const sheepCode = await web3.eth.getCode(contract)
                 assert.equal(sheepCode.length, 56, 'sheep wrong size');
                 const Sheep = await TrueUSD.at(contract)
+                // verify that calling the sheep improperly causes revert or assert
                 await assertRevert(Sheep.totalSupply(), {from: anotherAccount})
             }
             const reduceToNewWithRefund = await this.token.transfer(owner, BN(20*10**18), { from: oneHundred })
             const poolSizeUsed = await web3.eth.getStorageAt(this.token.address, '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
             assert.equal(poolSizeUsed, '0x02')
             assert.isBelow(reduceToNewWithRefund.receipt.gasUsed, reduceToNewNoRefund.receipt.gasUsed)
-            // verify that calling the sheep impoperly causes revert
             const selfdestructCode = await web3.eth.getCode(thirdContract)
             assert.equal(selfdestructCode,'0x', 'contract did not self destruct');
         })

--- a/test/helpers/assertRevert.js
+++ b/test/helpers/assertRevert.js
@@ -3,7 +3,7 @@ export default async promise => {
     await promise;
     assert.fail('Expected revert not received');
   } catch (error) {
-    const revertFound = error.message.search('revert') >= 0 || error.message.search('invalid opcode') >= 0;
+    const revertFound = error.message.search('revert') >= 0 || error.message.search('invalid opcode') >= 0 || error.message.search('invalid JUMP') >= 0;
     assert(revertFound, `Expected "revert", got ${error} instead`);
   }
 };


### PR DESCRIPTION
#### Changes
This modifies the Sheep contract so that they use JUMPI to assert instead of REVERT to revert.
We do not care about the gas of those who would improperly call our sheep contracts.
This saves 2416 gas in sponsorGas2, and 2 (1) gas in gasRefund39.
I also add tests to verify that the Sheep assert if you call them. 
Reviewers @terryli0095