### PR TITLE
[WIP] Prevent From Refilling When Full

### DIFF
--- a/contracts/Admin/TokenController.sol
+++ b/contracts/Admin/TokenController.sol
@@ -252,6 +252,7 @@ contract TokenController {
      */
     function refillRatifiedMintPool() external onlyMintRatifierOrOwner {
         if (msg.sender != owner) {
+            require(ratifiedMintPool != ratifiedMintLimit);
             address[2] memory refillApprovals = ratifiedPoolRefillApprovals;
             require(msg.sender != refillApprovals[0] && msg.sender != refillApprovals[1]);
             if (refillApprovals[0] == address(0)) {


### PR DESCRIPTION

#### Changes
This adds a restriction against ratifiers voting to refill the ratifier pool when the pool is full.
We don't want this to be possible because the vote is a blind endorsement of minting activity to come, when it is meant to be a vote endorsing prior activity.
Reviewers @terryli0095